### PR TITLE
Relax licence restrictions to support custom licences

### DIFF
--- a/poetry/core/factory.py
+++ b/poetry/core/factory.py
@@ -141,15 +141,6 @@ class Factory(object):
 
         if strict:
             # If strict, check the file more thoroughly
-
-            # Checking license
-            license = config.get("license")
-            if license:
-                try:
-                    license_by_id(license)
-                except ValueError:
-                    result["errors"].append("{} is not a valid license".format(license))
-
             if "dependencies" in config:
                 python_versions = config["dependencies"]["python"]
                 if python_versions == "*":

--- a/poetry/core/spdx/__init__.py
+++ b/poetry/core/spdx/__init__.py
@@ -17,7 +17,9 @@ def license_by_id(identifier):
     id = identifier.lower()
 
     if id not in _licenses:
-        raise ValueError("Invalid license id: {}".format(identifier))
+        if not identifier:
+            raise ValueError("A license identifier is required")
+        return License(identifier, identifier, False, False)
 
     return _licenses[id]
 

--- a/tests/spdx/test_license.py
+++ b/tests/spdx/test_license.py
@@ -1,0 +1,50 @@
+from poetry.core.spdx import license_by_id
+
+
+def test_classifier_name():
+    license = license_by_id("lgpl-3.0-or-later")
+
+    assert (
+        license.classifier_name
+        == "GNU Lesser General Public License v3 or later (LGPLv3+)"
+    )
+
+
+def test_classifier_name_no_classifer_osi_approved():
+    license = license_by_id("LiLiQ-R-1.1")
+
+    assert license.classifier_name is None
+
+
+def test_classifier_name_no_classifer():
+    license = license_by_id("Leptonica")
+
+    assert license.classifier_name == "Other/Proprietary License"
+
+
+def test_classifier():
+    license = license_by_id("lgpl-3.0-or-later")
+
+    assert license.classifier == (
+        "License :: "
+        "OSI Approved :: "
+        "GNU Lesser General Public License v3 or later (LGPLv3+)"
+    )
+
+
+def test_classifier_no_classifer_osi_approved():
+    license = license_by_id("LiLiQ-R-1.1")
+
+    assert license.classifier == "License :: OSI Approved"
+
+
+def test_classifier_no_classifer():
+    license = license_by_id("Leptonica")
+
+    assert license.classifier == "License :: Other/Proprietary License"
+
+
+def test_proprietary_license():
+    license = license_by_id("Proprietary")
+
+    assert "License :: Other/Proprietary License" == license.classifier

--- a/tests/spdx/test_license.py
+++ b/tests/spdx/test_license.py
@@ -48,3 +48,9 @@ def test_proprietary_license():
     license = license_by_id("Proprietary")
 
     assert "License :: Other/Proprietary License" == license.classifier
+
+
+def test_custom_license():
+    license = license_by_id("Amazon Software License")
+
+    assert "License :: Other/Proprietary License" == license.classifier

--- a/tests/spdx/test_main.py
+++ b/tests/spdx/test_main.py
@@ -1,0 +1,43 @@
+import pytest
+
+from poetry.core.spdx import license_by_id
+
+
+def test_license_by_id():
+    license = license_by_id("MIT")
+
+    assert license.id == "MIT"
+    assert license.name == "MIT License"
+    assert license.is_osi_approved
+    assert not license.is_deprecated
+
+    license = license_by_id("LGPL-3.0-or-later")
+
+    assert license.id == "LGPL-3.0-or-later"
+    assert license.name == "GNU Lesser General Public License v3.0 or later"
+    assert license.is_osi_approved
+    assert not license.is_deprecated
+
+
+def test_license_by_id_is_case_insensitive():
+    license = license_by_id("mit")
+
+    assert license.id == "MIT"
+
+    license = license_by_id("miT")
+
+    assert license.id == "MIT"
+
+
+def test_license_by_id_with_full_name():
+    license = license_by_id("GNU Lesser General Public License v3.0 or later")
+
+    assert license.id == "LGPL-3.0-or-later"
+    assert license.name == "GNU Lesser General Public License v3.0 or later"
+    assert license.is_osi_approved
+    assert not license.is_deprecated
+
+
+def test_license_by_id_invalid():
+    with pytest.raises(ValueError):
+        license_by_id("invalid")

--- a/tests/spdx/test_main.py
+++ b/tests/spdx/test_main.py
@@ -40,4 +40,13 @@ def test_license_by_id_with_full_name():
 
 def test_license_by_id_invalid():
     with pytest.raises(ValueError):
-        license_by_id("invalid")
+        license_by_id("")
+
+
+def test_license_by_id_custom():
+    license = license_by_id("Custom")
+
+    assert license.id == "Custom"
+    assert license.name == "Custom"
+    assert not license.is_osi_approved
+    assert not license.is_deprecated


### PR DESCRIPTION
This change adds support of use of custom licenses for projects. If the
value specified for `licence` is not in the SPDX License List or
"Proprietary", we treat it as a custom licence withe value (as is) as
the name.

As a side-effect, the validation of licence is no longer performed when
executing `poetry check`.

Resolves: python-poetry/poetry#2020