### PR TITLE
 Fix PEP-517 issues for projects using build scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-py${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
       run: |
         source $HOME/.poetry/env
@@ -81,7 +81,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-py${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
       run: |
         source $HOME/.poetry/env
@@ -118,7 +118,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-py${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
       run: |
         $env:Path += ";$env:Userprofile\.poetry\bin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 
 packages = [
     {include = "poetry"},
-    {include = "tests", format = "sdist"},
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
In order to do this, we introduce a context manager in sdist builder. This can also be reused for the editable builder in the poetry code base.

Resolves: python-poetry/poetry#1516

Removed tests inclusion in sdist due to python-poetry/poetry#2283. This was breaking CI with preview poetry release.