### PR TITLE
Handle whitespaces for PEP-440 constraints

### DIFF
--- a/poetry/core/semver/__init__.py
+++ b/poetry/core/semver/__init__.py
@@ -20,7 +20,7 @@ def parse_constraint(constraints):  # type: (str) -> VersionConstraint
     or_groups = []
     for constraints in or_constraints:
         and_constraints = re.split(
-            "(?<!^)(?<![=>< ,]) *(?<!-)[, ](?!-) *(?!,|$)", constraints
+            "(?<!^)(?<![~=>< ,]) *(?<!-)[, ](?!-) *(?!,|$)", constraints
         )
         constraint_objects = []
 

--- a/poetry/core/semver/patterns.py
+++ b/poetry/core/semver/patterns.py
@@ -14,8 +14,8 @@ _COMPLETE_VERSION = r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.(\d+))?{}(?:\+[^\s]+)?
 COMPLETE_VERSION = re.compile("(?i)" + _COMPLETE_VERSION)
 
 CARET_CONSTRAINT = re.compile(r"(?i)^\^({})$".format(_COMPLETE_VERSION))
-TILDE_CONSTRAINT = re.compile("(?i)^~(?!=)({})$".format(_COMPLETE_VERSION))
-TILDE_PEP440_CONSTRAINT = re.compile("(?i)^~=({})$".format(_COMPLETE_VERSION))
+TILDE_CONSTRAINT = re.compile(r"(?i)^~(?!=)\s*({})$".format(_COMPLETE_VERSION))
+TILDE_PEP440_CONSTRAINT = re.compile(r"(?i)^~=\s*({})$".format(_COMPLETE_VERSION))
 X_CONSTRAINT = re.compile(r"^(!=|==)?\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.[xX*])+$")
 BASIC_CONSTRAINT = re.compile(
     r"(?i)^(<>|!=|>=?|<=?|==?)?\s*({}|dev)".format(_COMPLETE_VERSION)

--- a/tests/semver/test_parse_constraint.py
+++ b/tests/semver/test_parse_constraint.py
@@ -1,0 +1,86 @@
+import pytest
+
+from poetry.core.semver import Version
+from poetry.core.semver import VersionRange
+from poetry.core.semver import VersionUnion
+from poetry.core.semver import parse_constraint
+
+
+@pytest.mark.parametrize(
+    "constraint,version",
+    [
+        ("~=3.8", VersionRange(min=Version(3, 8), max=Version(4, 0), include_min=True)),
+        (
+            "~= 3.8",
+            VersionRange(min=Version(3, 8), max=Version(4, 0), include_min=True),
+        ),
+        ("~3.8", VersionRange(min=Version(3, 8), max=Version(3, 9), include_min=True)),
+        ("~ 3.8", VersionRange(min=Version(3, 8), max=Version(3, 9), include_min=True)),
+        (">3.8", VersionRange(min=Version(3, 8))),
+        (">=3.8", VersionRange(min=Version(3, 8), include_min=True)),
+        (">= 3.8", VersionRange(min=Version(3, 8), include_min=True)),
+        (
+            ">3.8,<=6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            ">3.8,<= 6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            "> 3.8,<= 6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            "> 3.8,<=6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            ">3.8 ,<=6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            ">3.8, <=6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            ">3.8 , <=6.5",
+            VersionRange(min=Version(3, 8), max=Version(6, 5), include_max=True),
+        ),
+        (
+            "==3.8",
+            VersionRange(
+                min=Version(3, 8), max=Version(3, 8), include_min=True, include_max=True
+            ),
+        ),
+        (
+            "== 3.8",
+            VersionRange(
+                min=Version(3, 8), max=Version(3, 8), include_min=True, include_max=True
+            ),
+        ),
+        (
+            "~2.7 || ~3.8",
+            VersionUnion(
+                VersionRange(min=Version(2, 7), max=Version(2, 8), include_min=True),
+                VersionRange(min=Version(3, 8), max=Version(3, 9), include_min=True),
+            ),
+        ),
+        (
+            "~2.7||~3.8",
+            VersionUnion(
+                VersionRange(min=Version(2, 7), max=Version(2, 8), include_min=True),
+                VersionRange(min=Version(3, 8), max=Version(3, 9), include_min=True),
+            ),
+        ),
+        (
+            "~ 2.7||~ 3.8",
+            VersionUnion(
+                VersionRange(min=Version(2, 7), max=Version(2, 8), include_min=True),
+                VersionRange(min=Version(3, 8), max=Version(3, 9), include_min=True),
+            ),
+        ),
+    ],
+)
+def test_parse_constraint(constraint, version):
+    assert parse_constraint(constraint) == version


### PR DESCRIPTION
* fix incorrect parsing of spaces when parsing version constraints
* add tests for `parse_constraint`

This issue was discovered while installing `vendoring` package. This package uses `~= 3.8.0` for its python version requirement, which was failing due to the whitespace.

```console
$ poetry add -D vendoring
Using version ^0.2.2 for vendoring

Updating dependencies
Resolving dependencies... (0.0s)

[ValueError]
Could not parse version constraint: ~= 3.8.0
```