### PR TITLE
Improve support for PEP-440 direct references

### DIFF
--- a/poetry/core/masonry/builders/complete.py
+++ b/poetry/core/masonry/builders/complete.py
@@ -38,14 +38,12 @@ class CompleteBuilder(Builder):
 
                 with self.unpacked_tarball(sdist_file) as tmpdir:
                     WheelBuilder.make_in(
-                        Factory().create_poetry(tmpdir),
-                        dist_dir,
-                        original=self._poetry,
+                        Factory().create_poetry(tmpdir), dist_dir, original=self._poetry
                     )
         else:
             with self.unpacked_tarball(sdist_file) as tmpdir:
                 WheelBuilder.make_in(
-                    Factory().create_poetry(tmpdir), dist_dir, original=self._poetry,
+                    Factory().create_poetry(tmpdir), dist_dir, original=self._poetry
                 )
 
     @classmethod

--- a/poetry/core/packages/directory_dependency.py
+++ b/poetry/core/packages/directory_dependency.py
@@ -79,3 +79,14 @@ class DirectoryDependency(Dependency):
 
     def is_directory(self):
         return True
+
+    @property
+    def base_pep_508_name(self):  # type: () -> str
+        requirement = self.pretty_name
+
+        if self.extras:
+            requirement += "[{}]".format(",".join(self.extras))
+
+        requirement += " @ {}".format(str(self.path))
+
+        return requirement

--- a/poetry/core/packages/file_dependency.py
+++ b/poetry/core/packages/file_dependency.py
@@ -4,6 +4,7 @@ import io
 from poetry.core._vendor.pkginfo.distribution import HEADER_ATTRS
 from poetry.core._vendor.pkginfo.distribution import HEADER_ATTRS_2_0
 
+from poetry.core.packages.utils.utils import path_to_url
 from poetry.core.utils._compat import Path
 
 from .dependency import Dependency
@@ -59,3 +60,15 @@ class FileDependency(Dependency):
                 h.update(content)
 
         return h.hexdigest()
+
+    @property
+    def base_pep_508_name(self):  # type: () -> str
+        requirement = self.pretty_name
+
+        if self.extras:
+            requirement += "[{}]".format(",".join(self.extras))
+
+        path = path_to_url(self.path) if self.path.is_absolute() else self.path
+        requirement += " @ {}".format(path)
+
+        return requirement

--- a/poetry/core/utils/_compat.py
+++ b/poetry/core/utils/_compat.py
@@ -1,10 +1,10 @@
 import sys
 
+import poetry.core._vendor.six.moves.urllib.parse as urllib_parse
 
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+
+urlparse = urllib_parse
+
 
 try:  # Python 2
     long = long

--- a/poetry/core/version/requirements.py
+++ b/poetry/core/version/requirements.py
@@ -216,10 +216,14 @@ class Requirement(object):
         self.name = req.name
         if req.url:
             parsed_url = urlparse.urlparse(req.url)
-            if not (parsed_url.scheme and parsed_url.netloc) or (
-                not parsed_url.scheme and not parsed_url.netloc
-            ):
-                raise InvalidRequirement("Invalid URL given")
+            if parsed_url.scheme == "file":
+                if urlparse.urlunparse(parsed_url) != req.url:
+                    raise InvalidRequirement("Invalid URL given")
+            elif (
+                not (parsed_url.scheme and parsed_url.netloc)
+                or (not parsed_url.scheme and not parsed_url.netloc)
+            ) and not parsed_url.path:
+                raise InvalidRequirement("Invalid URL: {0}".format(req.url))
             self.url = req.url
         else:
             self.url = None

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -11,7 +11,7 @@ def test_builder_find_excluded_files(mocker):
     p.return_value = []
 
     builder = Builder(
-        Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete"),
+        Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete")
     )
 
     assert builder.find_excluded_files() == {"my_package/sub_pkg1/extra_file.xml"}
@@ -24,7 +24,7 @@ def test_builder_find_case_sensitive_excluded_files(mocker):
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "case_sensitive_exclusions"
-        ),
+        )
     )
 
     assert builder.find_excluded_files() == {
@@ -45,7 +45,7 @@ def test_builder_find_invalid_case_sensitive_excluded_files(mocker):
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "invalid_case_sensitive_exclusions"
-        ),
+        )
     )
 
     assert {"my_package/Bar/foo/bar/Foo.py"} == builder.find_excluded_files()
@@ -53,7 +53,7 @@ def test_builder_find_invalid_case_sensitive_excluded_files(mocker):
 
 def test_get_metadata_content():
     builder = Builder(
-        Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete"),
+        Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete")
     )
 
     metadata = builder.get_metadata_content()
@@ -103,7 +103,7 @@ def test_get_metadata_content():
 
 def test_metadata_homepage_default():
     builder = Builder(
-        Factory().create_poetry(Path(__file__).parent / "fixtures" / "simple_version"),
+        Factory().create_poetry(Path(__file__).parent / "fixtures" / "simple_version")
     )
 
     metadata = Parser().parsestr(builder.get_metadata_content())
@@ -115,7 +115,7 @@ def test_metadata_with_vcs_dependencies():
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_vcs_dependency"
-        ),
+        )
     )
 
     metadata = Parser().parsestr(builder.get_metadata_content())
@@ -129,7 +129,7 @@ def test_metadata_with_url_dependencies():
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_url_dependency"
-        ),
+        )
     )
 
     metadata = Parser().parsestr(builder.get_metadata_content())

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -1,5 +1,6 @@
 import pytest
 
+from poetry.core.packages import dependency_from_pep_508
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.core.utils._compat import Path
 
@@ -10,3 +11,47 @@ DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "
 def test_directory_dependency_must_exist():
     with pytest.raises(ValueError):
         DirectoryDependency("demo", DIST_PATH / "invalid")
+
+
+def _test_directory_dependency_pep_508(name, path, pep_508_input, pep_508_output=None):
+    dep = dependency_from_pep_508(pep_508_input, relative_to=Path(__file__).parent)
+
+    assert dep.is_directory()
+    assert dep.name == name
+    assert dep.path == path
+    assert dep.to_pep_508() == pep_508_output or pep_508_input
+
+
+def test_directory_dependency_pep_508_local_absolute():
+    path = (
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "project_with_multi_constraints_dependency"
+    )
+    requirement = "{} @ file://{}".format("demo", path.as_posix())
+    _test_directory_dependency_pep_508("demo", path, requirement)
+
+    requirement = "{} @ {}".format("demo", path)
+    _test_directory_dependency_pep_508("demo", path, requirement)
+
+
+def test_directory_dependency_pep_508_localhost():
+    path = (
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "project_with_multi_constraints_dependency"
+    )
+    requirement = "{} @ file://localhost{}".format("demo", path.as_posix())
+    requirement_expected = "{} @ file://{}".format("demo", path.as_posix())
+    _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
+
+
+def test_directory_dependency_pep_508_local_relative():
+    path = Path("..") / "fixtures" / "project_with_multi_constraints_dependency"
+
+    with pytest.raises(ValueError):
+        requirement = "{} @ file://{}".format("demo", path.as_posix())
+        _test_directory_dependency_pep_508("demo", path, requirement)
+
+    requirement = "{} @ {}".format("demo", path)
+    _test_directory_dependency_pep_508("demo", path, requirement)

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -1,6 +1,7 @@
 import pytest
 
 from poetry.core.packages import FileDependency
+from poetry.core.packages import dependency_from_pep_508
 from poetry.core.utils._compat import Path
 
 
@@ -15,3 +16,46 @@ def test_file_dependency_wrong_path():
 def test_file_dependency_dir():
     with pytest.raises(ValueError):
         FileDependency("demo", DIST_PATH)
+
+
+def _test_file_dependency_pep_508(
+    mocker, name, path, pep_508_input, pep_508_output=None
+):
+    mocker.patch.object(Path, "exists").return_value = True
+    mocker.patch.object(Path, "is_file").return_value = True
+
+    dep = dependency_from_pep_508(pep_508_input, relative_to=Path(__file__).parent)
+
+    assert dep.is_file()
+    assert dep.name == name
+    assert dep.path == path
+    assert dep.to_pep_508() == pep_508_output or pep_508_input
+
+
+def test_file_dependency_pep_508_local_file_absolute(mocker):
+    path = DIST_PATH / "demo-0.2.0.tar.gz"
+    requirement = "{} @ file://{}".format("demo", path.as_posix())
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+
+    requirement = "{} @ {}".format("demo", path)
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+
+
+def test_file_dependency_pep_508_local_file_localhost(mocker):
+    path = DIST_PATH / "demo-0.2.0.tar.gz"
+    requirement = "{} @ file://localhost{}".format("demo", path.as_posix())
+    requirement_expected = "{} @ file://{}".format("demo", path.as_posix())
+    _test_file_dependency_pep_508(
+        mocker, "demo", path, requirement, requirement_expected
+    )
+
+
+def test_file_dependency_pep_508_local_file_relative_path(mocker):
+    path = Path("..") / "fixtures" / "distributions" / "demo-0.2.0.tar.gz"
+
+    with pytest.raises(ValueError):
+        requirement = "{} @ file://{}".format("demo", path.as_posix())
+        _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+
+    requirement = "{} @ {}".format("demo", path)
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement)

--- a/tests/packages/utils/test_utils_urls.py
+++ b/tests/packages/utils/test_utils_urls.py
@@ -1,0 +1,63 @@
+# These test scenarios are ported over from pypa/pip
+# https://raw.githubusercontent.com/pypa/pip/b447f438df08303f4f07f2598f190e73876443ba/tests/unit/test_urls.py
+
+import sys
+
+from poetry.core._vendor.six.moves.urllib.request import pathname2url  # noqa
+
+import pytest
+
+from poetry.core.packages import path_to_url
+from poetry.core.packages import url_to_path
+from poetry.core.utils._compat import Path
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+def test_path_to_url_unix():
+    assert path_to_url("/tmp/file") == "file:///tmp/file"
+    path = Path(".") / "file"
+    assert path_to_url("file") == "file://" + path.absolute().as_posix()
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_path_to_url_win():
+    assert path_to_url("c:/tmp/file") == "file:///c:/tmp/file"
+    assert path_to_url("c:\\tmp\\file") == "file:///c:/tmp/file"
+    assert path_to_url(r"\\unc\as\path") == "file://unc/as/path"
+    path = Path(".") / "file"
+    assert path_to_url("file") == "file:///" + path.absolute().as_posix()
+
+
+@pytest.mark.parametrize(
+    "url,win_expected,non_win_expected",
+    [
+        ("file:tmp", "tmp", "tmp"),
+        ("file:c:/path/to/file", r"C:\path\to\file", "c:/path/to/file"),
+        ("file:/path/to/file", r"\path\to\file", "/path/to/file"),
+        ("file://localhost/tmp/file", r"\tmp\file", "/tmp/file"),
+        ("file://localhost/c:/tmp/file", r"C:\tmp\file", "/c:/tmp/file"),
+        ("file://somehost/tmp/file", r"\\somehost\tmp\file", None),
+        ("file:///tmp/file", r"\tmp\file", "/tmp/file"),
+        ("file:///c:/tmp/file", r"C:\tmp\file", "/c:/tmp/file"),
+    ],
+)
+def test_url_to_path(url, win_expected, non_win_expected):
+    if sys.platform == "win32":
+        expected_path = win_expected
+    else:
+        expected_path = non_win_expected
+
+    if expected_path is None:
+        with pytest.raises(ValueError):
+            url_to_path(url)
+    else:
+        assert url_to_path(url) == Path(expected_path)
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_url_to_path_path_to_url_symmetry_win():
+    path = r"C:\tmp\file"
+    assert url_to_path(path_to_url(path)) == Path(path)
+
+    unc_path = r"\\unc\share\path"
+    assert url_to_path(path_to_url(unc_path)) == Path(unc_path)


### PR DESCRIPTION
With this change we allow for PEP-508 string for file dependencies
to use PEP-440 direct reference using the file URI scheme (RFC-8089).

Note that this implementation will not allow non RFC-8089 file path
references. In order to allow for sdist to be portable in sane use
cases, we ensure that relative path dependencies do not use the
file URI scheme, but preserve path if relative or directories.

In addition to file resource, directory dependencies now support
the same scheme.

References:
- https://www.python.org/dev/peps/pep-0508/#backwards-compatibility
- https://www.python.org/dev/peps/pep-0440/#direct-references
- https://tools.ietf.org/html/rfc8089
- https://discuss.python.org/t/what-is-the-correct-interpretation-of-path-based-pep-508-uri-reference/2815/11
