### PR TITLE
builder.sdist: remove setuptools import

### DIFF
--- a/poetry/core/masonry/builders/sdist.py
+++ b/poetry/core/masonry/builders/sdist.py
@@ -26,7 +26,7 @@ from .builder import Builder
 
 SETUP = """\
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from distutils.core import setup
 
 {before}
 setup_kwargs = {{

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 skipsdist = true
+isolated_build = True
 envlist = py27, py35, py36, py37, py38, pypy, pypy3
 
 [testenv]


### PR DESCRIPTION
It appears we do not really need setuptools for now. The use of setuptools was preventing pip from installing poetry correctly for PEP-517 builds when `--no-binary :all:` was being used. Additionally, now we can install poetry-core from sdist as expected. 

Resolves: python-poetry/poetry#454