### PR TITLE
utils: add missing comma in list of valid url schemes

### DIFF
--- a/poetry/core/packages/utils/utils.py
+++ b/poetry/core/packages/utils/utils.py
@@ -96,7 +96,8 @@ def is_url(name):
         "hg",
         "bzr",
         "sftp",
-        "svn" "ssh",
+        "svn",
+        "ssh",
     ]
 
 


### PR DESCRIPTION
See also: python-poetry/poetry#2373