### PR TITLE
Release 1.0.0a7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [1.0.0a7] - 2020-05-06
+
+### Added
+
+- Added support for format-specific includes via the `include` property ([#6](https://github.com/python-poetry/core/pull/6)).
+
+### Changed
+
+- Allow url dependencies in multiple constraints dependencies ([#32](https://github.com/python-poetry/core/pull/32)).
+
+### Fixed
+
+- Fixed PEP 508 representation and parsing of VCS dependencies ([#30](https://github.com/python-poetry/core/pull/30)).
+
+
 ## [1.0.0a6] - 2020-04-24
 
 
@@ -25,5 +40,6 @@
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/1.0.0a6...master
+[Unreleased]: https://github.com/python-poetry/poetry/compare/1.0.0a7...master
+[1.0.0a7]: https://github.com/python-poetry/poetry/releases/tag/1.0.0a7
 [1.0.0a6]: https://github.com/python-poetry/poetry/releases/tag/1.0.0a6

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     # noinspection PyUnresolvedReferences
     from pathlib2 import Path
 
-__version__ = "1.0.0a6"
+__version__ = "1.0.0a7"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.0.0a6"
+version = "1.0.0a7"
 description = "Core utilities for Poetry"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Added

- Added support for format-specific includes via the `include` property ([#6](https://github.com/python-poetry/core/pull/6)).

### Changed

- Allow url dependencies in multiple constraints dependencies ([#32](https://github.com/python-poetry/core/pull/32)).

### Fixed

- Fixed PEP 508 representation and parsing of VCS dependencies ([#30](https://github.com/python-poetry/core/pull/30)).

